### PR TITLE
[FEAT] 달력 선택 뷰, 카테고리 수정/삭제 완료

### DIFF
--- a/Money-Planner/Money-Planner.xcodeproj/project.pbxproj
+++ b/Money-Planner/Money-Planner.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		20118A112B56A86100B2569E /* ConsumeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20118A102B56A86100B2569E /* ConsumeViewController.swift */; };
 		202754242B7FBF860084A757 /* ExpenseTapController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202754232B7FBF860084A757 /* ExpenseTapController.swift */; };
 		205894022B825A92008F536D /* ExpenseZeroDayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205894012B825A92008F536D /* ExpenseZeroDayView.swift */; };
+		205894042B825B36008F536D /* OverViewExpenseResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205894032B825B36008F536D /* OverViewExpenseResponse.swift */; };
 		206C58D42B623C43008410C1 /* CategoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206C58D32B623C43008410C1 /* CategoryCell.swift */; };
 		206C58D82B626465008410C1 /* CategoryModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206C58D72B626465008410C1 /* CategoryModalViewController.swift */; };
 		206C58DF2B6306FE008410C1 /* CalendartModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206C58DE2B6306FE008410C1 /* CalendartModalViewController.swift */; };
@@ -167,6 +168,7 @@
 		20118A102B56A86100B2569E /* ConsumeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsumeViewController.swift; sourceTree = "<group>"; };
 		202754232B7FBF860084A757 /* ExpenseTapController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTapController.swift; sourceTree = "<group>"; };
 		205894012B825A92008F536D /* ExpenseZeroDayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseZeroDayView.swift; sourceTree = "<group>"; };
+		205894032B825B36008F536D /* OverViewExpenseResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverViewExpenseResponse.swift; sourceTree = "<group>"; };
 		206C58D32B623C43008410C1 /* CategoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCell.swift; sourceTree = "<group>"; };
 		206C58D72B626465008410C1 /* CategoryModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryModalViewController.swift; sourceTree = "<group>"; };
 		206C58DE2B6306FE008410C1 /* CalendartModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendartModalViewController.swift; sourceTree = "<group>"; };
@@ -392,6 +394,7 @@
 				208C90CC2B7BBC6700C67960 /* ExpenseCreateResponse.swift */,
 				208C90CE2B7BBC8400C67960 /* ExpenseCreateRequest.swift */,
 				208C90D02B7BD33300C67960 /* UpdateExpenseRequest.swift */,
+				205894032B825B36008F536D /* OverViewExpenseResponse.swift */,
 			);
 			path = Expense;
 			sourceTree = "<group>";
@@ -979,6 +982,7 @@
 				D253EEAD2B79FE8400A4FC1C /* UIScrollView.swift in Sources */,
 				208C90D72B7F7FBB00C67960 /* CategoryIconCell.swift in Sources */,
 				D2D0B7412B6BACAB003B6B5E /* HomeNow.swift in Sources */,
+				205894042B825B36008F536D /* OverViewExpenseResponse.swift in Sources */,
 				7A4C67432B5A4B22008BCAC9 /* SmallButtonView.swift in Sources */,
 				208C90912B6AB7A200C67960 /* MufflerViewModel.swift in Sources */,
 				202754242B7FBF860084A757 /* ExpenseTapController.swift in Sources */,

--- a/Money-Planner/Money-Planner.xcodeproj/project.pbxproj
+++ b/Money-Planner/Money-Planner.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		20118A112B56A86100B2569E /* ConsumeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20118A102B56A86100B2569E /* ConsumeViewController.swift */; };
 		202754242B7FBF860084A757 /* ExpenseTapController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202754232B7FBF860084A757 /* ExpenseTapController.swift */; };
+		205894022B825A92008F536D /* ExpenseZeroDayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205894012B825A92008F536D /* ExpenseZeroDayView.swift */; };
 		206C58D42B623C43008410C1 /* CategoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206C58D32B623C43008410C1 /* CategoryCell.swift */; };
 		206C58D82B626465008410C1 /* CategoryModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206C58D72B626465008410C1 /* CategoryModalViewController.swift */; };
 		206C58DF2B6306FE008410C1 /* CalendartModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206C58DE2B6306FE008410C1 /* CalendartModalViewController.swift */; };
@@ -165,6 +166,7 @@
 /* Begin PBXFileReference section */
 		20118A102B56A86100B2569E /* ConsumeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsumeViewController.swift; sourceTree = "<group>"; };
 		202754232B7FBF860084A757 /* ExpenseTapController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTapController.swift; sourceTree = "<group>"; };
+		205894012B825A92008F536D /* ExpenseZeroDayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseZeroDayView.swift; sourceTree = "<group>"; };
 		206C58D32B623C43008410C1 /* CategoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCell.swift; sourceTree = "<group>"; };
 		206C58D72B626465008410C1 /* CategoryModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryModalViewController.swift; sourceTree = "<group>"; };
 		206C58DE2B6306FE008410C1 /* CalendartModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendartModalViewController.swift; sourceTree = "<group>"; };
@@ -633,6 +635,7 @@
 				551E8B752B7D13490008476B /* zeroModalView.swift */,
 				551E8B772B7D135E0008476B /* evaluationModalView.swift */,
 				208F5E7A2B80BA0B00107735 /* ExpensePopupModalView.swift */,
+				205894012B825A92008F536D /* ExpenseZeroDayView.swift */,
 			);
 			name = Notification;
 			path = ../../Notification;
@@ -1011,6 +1014,7 @@
 				7A610AD22B49004200D3096F /* MyPageViewController.swift in Sources */,
 				7A610AD22B49004200D3096F /* MyPageViewController.swift in Sources */,
 				D20D703A2B68C591006D6762 /* TestRepository.swift in Sources */,
+				205894022B825A92008F536D /* ExpenseZeroDayView.swift in Sources */,
 				D20D70022B5FF088006D6762 /* Formatter.swift in Sources */,
 				7AC060FF2B4C5D78008C0E63 /* Design.swift in Sources */,
 				7A610AF22B49421F00D3096F /* KakaoLoginViewController.swift in Sources */,

--- a/Money-Planner/Money-Planner.xcodeproj/project.pbxproj
+++ b/Money-Planner/Money-Planner.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		202754242B7FBF860084A757 /* ExpenseTapController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202754232B7FBF860084A757 /* ExpenseTapController.swift */; };
 		205894022B825A92008F536D /* ExpenseZeroDayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205894012B825A92008F536D /* ExpenseZeroDayView.swift */; };
 		205894042B825B36008F536D /* OverViewExpenseResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205894032B825B36008F536D /* OverViewExpenseResponse.swift */; };
+		205894072B827B58008F536D /* UpdateCategoryRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205894062B827B58008F536D /* UpdateCategoryRequest.swift */; };
+		2058940A2B827BF3008F536D /* DeleteCategoryResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205894092B827BF3008F536D /* DeleteCategoryResponse.swift */; };
 		206C58D42B623C43008410C1 /* CategoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206C58D32B623C43008410C1 /* CategoryCell.swift */; };
 		206C58D82B626465008410C1 /* CategoryModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206C58D72B626465008410C1 /* CategoryModalViewController.swift */; };
 		206C58DF2B6306FE008410C1 /* CalendartModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206C58DE2B6306FE008410C1 /* CalendartModalViewController.swift */; };
@@ -169,6 +171,8 @@
 		202754232B7FBF860084A757 /* ExpenseTapController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTapController.swift; sourceTree = "<group>"; };
 		205894012B825A92008F536D /* ExpenseZeroDayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseZeroDayView.swift; sourceTree = "<group>"; };
 		205894032B825B36008F536D /* OverViewExpenseResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverViewExpenseResponse.swift; sourceTree = "<group>"; };
+		205894062B827B58008F536D /* UpdateCategoryRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UpdateCategoryRequest.swift; path = "Money-Planner/ViewModel/Expense/UpdateCategoryRequest.swift"; sourceTree = SOURCE_ROOT; };
+		205894092B827BF3008F536D /* DeleteCategoryResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteCategoryResponse.swift; sourceTree = "<group>"; };
 		206C58D32B623C43008410C1 /* CategoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCell.swift; sourceTree = "<group>"; };
 		206C58D72B626465008410C1 /* CategoryModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryModalViewController.swift; sourceTree = "<group>"; };
 		206C58DE2B6306FE008410C1 /* CalendartModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendartModalViewController.swift; sourceTree = "<group>"; };
@@ -335,6 +339,22 @@
 			path = Consume;
 			sourceTree = "<group>";
 		};
+		205894052B827B4A008F536D /* update */ = {
+			isa = PBXGroup;
+			children = (
+				205894062B827B58008F536D /* UpdateCategoryRequest.swift */,
+			);
+			path = update;
+			sourceTree = "<group>";
+		};
+		205894082B827BDE008F536D /* delete */ = {
+			isa = PBXGroup;
+			children = (
+				205894092B827BF3008F536D /* DeleteCategoryResponse.swift */,
+			);
+			path = delete;
+			sourceTree = "<group>";
+		};
 		206C58D02B617396008410C1 /* Modal */ = {
 			isa = PBXGroup;
 			children = (
@@ -446,6 +466,8 @@
 		208F5E852B81259100107735 /* Category */ = {
 			isa = PBXGroup;
 			children = (
+				205894082B827BDE008F536D /* delete */,
+				205894052B827B4A008F536D /* update */,
 				208F5E8D2B81323500107735 /* get */,
 				208F5E8C2B81321400107735 /* create */,
 			);
@@ -948,6 +970,7 @@
 				7A610ABC2B47FA8E00D3096F /* LoginViewController.swift in Sources */,
 				206C58D42B623C43008410C1 /* CategoryCell.swift in Sources */,
 				7A610AF02B49414100D3096F /* RegisterProfileViewController.swift in Sources */,
+				205894072B827B58008F536D /* UpdateCategoryRequest.swift in Sources */,
 				208C90D52B7F7B6100C67960 /* CategoryIconSelectionViewController.swift in Sources */,
 				7A4C67462B5A4B77008BCAC9 /* MainTextField.swift in Sources */,
 				D20D70142B612BB4006D6762 /* CategoryTableView.swift in Sources */,
@@ -1039,6 +1062,7 @@
 				20AFDD8F2B654CB4008F8AB9 /* ChooseDayView.swift in Sources */,
 				208F5E872B8125B300107735 /* GetCategoryResponse.swift in Sources */,
 				208C908F2B6AB78900C67960 /* MufflerAPI.swift in Sources */,
+				2058940A2B827BF3008F536D /* DeleteCategoryResponse.swift in Sources */,
 				D217EBEF2B7460BC00EB6BF3 /* CategoryAPI.swift in Sources */,
 				7A610AEE2B493F6D00D3096F /* RegisterUsageViewController.swift in Sources */,
 				D20D6FED2B5B9962006D6762 /* MainCalendarView.swift in Sources */,

--- a/Money-Planner/Money-Planner.xcodeproj/project.pbxproj
+++ b/Money-Planner/Money-Planner.xcodeproj/project.pbxproj
@@ -396,7 +396,8 @@
 				208C90D02B7BD33300C67960 /* UpdateExpenseRequest.swift */,
 				205894032B825B36008F536D /* OverViewExpenseResponse.swift */,
 			);
-			path = Expense;
+			name = Expense;
+			path = ../ViewModel/Expense;
 			sourceTree = "<group>";
 		};
 		208F5E7C2B80C7EF00107735 /* DailyPlan */ = {
@@ -404,7 +405,8 @@
 			children = (
 				208F5E7D2B80C81E00107735 /* ZeroDayRequest.swift */,
 			);
-			path = DailyPlan;
+			name = DailyPlan;
+			path = ../ViewModel/DailyPlan;
 			sourceTree = "<group>";
 		};
 		208F5E7F2B8102A400107735 /* Calendar */ = {
@@ -447,7 +449,8 @@
 				208F5E8D2B81323500107735 /* get */,
 				208F5E8C2B81321400107735 /* create */,
 			);
-			path = Category;
+			name = Category;
+			path = ../ViewModel/Category;
 			sourceTree = "<group>";
 		};
 		208F5E8C2B81321400107735 /* create */ = {
@@ -608,9 +611,6 @@
 		7A610ACD2B480B1400D3096F /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
-				208F5E852B81259100107735 /* Category */,
-				208F5E7C2B80C7EF00107735 /* DailyPlan */,
-				208C90CB2B7BBC5500C67960 /* Expense */,
 				D20D701F2B66FE8F006D6762 /* Home */,
 			);
 			path = ViewModel;
@@ -619,6 +619,9 @@
 		7A610ACE2B480B5B00D3096F /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				208F5E852B81259100107735 /* Category */,
+				208F5E7C2B80C7EF00107735 /* DailyPlan */,
+				208C90CB2B7BBC5500C67960 /* Expense */,
 				208C90BC2B6FE4CF00C67960 /* Member */,
 				7A610AE42B491ED600D3096F /* Dummy.swift */,
 				D20D6FF22B5D67B1006D6762 /* Category.swift */,

--- a/Money-Planner/Money-Planner/CustomView/Category/AddCategoryViewController.swift
+++ b/Money-Planner/Money-Planner/CustomView/Category/AddCategoryViewController.swift
@@ -138,11 +138,10 @@ class AddCategoryViewController: UIViewController,UITextFieldDelegate, CategoryI
             
                 
                 if let index = categories.firstIndex(where: { $0.name == name }) {
-                    print(index)
-                    print(self?.categories[index].type)
                     if let type = self?.categories[index].type {
                         if type == "CUSTOM"{
                             print("타입 : 커스텀")
+                            self?.currIcon = icon
                             self?.categories.remove(at: index)
                             // 삭제 버튼 추가
                             self?.setupDelete()
@@ -413,6 +412,7 @@ class AddCategoryViewController: UIViewController,UITextFieldDelegate, CategoryI
     
     private func fixCategoryComplete(){
         print("카테고리 수정 완료")
+        print(categoryId, currText, currIcon)
         let request = UpdateCategoryRequest(categoryId: categoryId, name: currText, icon: currIcon)
         viewModel.updateCategory(request: request)
             .subscribe(onNext: {  response in
@@ -427,7 +427,6 @@ class AddCategoryViewController: UIViewController,UITextFieldDelegate, CategoryI
     }
     @objc private func deleteCategoryComplete(){
         print("카테고리 삭제 완료")
-        
         viewModel.deleteCategory(categoryId: categoryId)
             .subscribe(onNext: {  response in
              print(response)

--- a/Money-Planner/Money-Planner/CustomView/Category/AddCategoryViewController.swift
+++ b/Money-Planner/Money-Planner/CustomView/Category/AddCategoryViewController.swift
@@ -47,6 +47,7 @@ class AddCategoryViewController: UIViewController,UITextFieldDelegate, CategoryI
     private lazy var headerView = HeaderView(title: "카테고리 추가")
     var currText : String = ""
     var currIcon : String
+    let categoryId : Int64
     let picContainer : UIView = {
         let view = UIView()
         //view.backgroundColor = .red
@@ -100,8 +101,9 @@ class AddCategoryViewController: UIViewController,UITextFieldDelegate, CategoryI
     }()
     
     // 이니셜라이저를 정의하여 expenseId를 전달 받을 수 있도록 합니다.
-    init(name: String, icon: String) {
+    init(name: String, icon: String, id : Int64) {
         initName = name
+        categoryId = id
         if name != "" {
             // 수정 화면 : 카테고리 이름과 아이콘 반영
             VCType = "FIX"

--- a/Money-Planner/Money-Planner/CustomView/Category/AddCategoryViewController.swift
+++ b/Money-Planner/Money-Planner/CustomView/Category/AddCategoryViewController.swift
@@ -288,3 +288,4 @@ class AddCategoryViewController: UIViewController,UITextFieldDelegate, CategoryI
         dismiss(animated: true, completion: nil)
     }
 }
+

--- a/Money-Planner/Money-Planner/CustomView/Category/AddCategoryViewController.swift
+++ b/Money-Planner/Money-Planner/CustomView/Category/AddCategoryViewController.swift
@@ -139,16 +139,22 @@ class AddCategoryViewController: UIViewController,UITextFieldDelegate, CategoryI
                 
                 if let index = categories.firstIndex(where: { $0.name == name }) {
                     print(index)
-                    if self?.categories[index].type == "CUSTOM"{
-                        self?.categories.remove(at: index)
-                        // 삭제 버튼 추가
-                        self?.setupDelete()
+                    print(self?.categories[index].type)
+                    if let type = self?.categories[index].type {
+                        if type == "CUSTOM"{
+                            print("타입 : 커스텀")
+                            self?.categories.remove(at: index)
+                            // 삭제 버튼 추가
+                            self?.setupDelete()
+                        }
+                        // 디폴트
+                        if type == "DEFAULT"{
+                            print("타입 : 디폴트 ")
+                            self?.categories.remove(at: index)
+                            self?.picButton.isUserInteractionEnabled = false
+                        }
                     }
-                    // 디폴트
-                    if self?.categories[index].type == "DEFAULT"{
-                        self?.categories.remove(at: index)
-                        self?.picButton.isUserInteractionEnabled = false
-                    }
+                   
                     
                 }
                 }, onError: { error in
@@ -407,11 +413,31 @@ class AddCategoryViewController: UIViewController,UITextFieldDelegate, CategoryI
     
     private func fixCategoryComplete(){
         print("카테고리 수정 완료")
-        
-        
+        let request = UpdateCategoryRequest(categoryId: categoryId, name: currText, icon: currIcon)
+        viewModel.updateCategory(request: request)
+            .subscribe(onNext: {  response in
+             print(response)
+            }, onError: { error in
+                // 에러 처리
+                print("Error: \(error)")
+            })
+            .disposed(by: disposeBag)
+        // 모달 닫기
+        dismiss(animated: true)
     }
     @objc private func deleteCategoryComplete(){
         print("카테고리 삭제 완료")
+        
+        viewModel.deleteCategory(categoryId: categoryId)
+            .subscribe(onNext: {  response in
+             print(response)
+            }, onError: { error in
+                // 에러 처리
+                print("Error: \(error)")
+            })
+            .disposed(by: disposeBag)
+        // 모달 닫기
+        dismiss(animated: true)
         
     }
 }

--- a/Money-Planner/Money-Planner/CustomView/Category/CategoryIconCell.swift
+++ b/Money-Planner/Money-Planner/CustomView/Category/CategoryIconCell.swift
@@ -77,3 +77,4 @@ class CategoryIconCell: UICollectionViewCell {
 //        }
 //    }
 }
+

--- a/Money-Planner/Money-Planner/CustomView/Category/CategoryIconSelectionViewController.swift
+++ b/Money-Planner/Money-Planner/CustomView/Category/CategoryIconSelectionViewController.swift
@@ -202,3 +202,4 @@ class CategoryIconSelectionViewController: UIViewController, UICollectionViewDel
         return CGSize(width: itemWidth, height: itemWidth)
     }
 }
+

--- a/Money-Planner/Money-Planner/CustomView/Category/CategoryModalViewController.swift
+++ b/Money-Planner/Money-Planner/CustomView/Category/CategoryModalViewController.swift
@@ -15,7 +15,7 @@ protocol CategorySelectionDelegate: AnyObject {
     func AddCategory()
 }
 
-// 카테고리 선택 뷰 
+// 카테고리 선택 뷰
 class CategoryModalViewController : UIViewController,UICollectionViewDelegate,UICollectionViewDataSource {
     var addCatName : String = ""
     var addCatIconName : String = ""
@@ -187,6 +187,7 @@ class CategoryModalViewController : UIViewController,UICollectionViewDelegate,UI
     
     
 }
+
 
 
 

--- a/Money-Planner/Money-Planner/CustomView/Category/CategoryTableView.swift
+++ b/Money-Planner/Money-Planner/CustomView/Category/CategoryTableView.swift
@@ -7,9 +7,18 @@
 
 import Foundation
 import UIKit
+protocol CategoryTableViewDelegate: AnyObject {
+    func categoryDidSelect(at indexPath: IndexPath)
+}
 
-class CategoryTableView : UIView{
+class CategoryTableView : UIView, AddCategoryViewDelegate{
+    func AddCategoryCompleted(_ name: String, iconName: String) {
+        
+    }
     
+    
+    weak var delegate: CategoryTableViewDelegate?
+
     
     private let tableView: UITableView = {
         let table = UITableView()
@@ -93,7 +102,7 @@ extension CategoryTableView : UITableViewDelegate, UITableViewDataSource{
     func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
         return .none
     }
-    
+     
     // editing = true 일 때 왼쪽 버튼이 나오기 위해 들어오는 indent 없애기
     func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
         return false
@@ -108,6 +117,8 @@ extension CategoryTableView : UITableViewDelegate, UITableViewDataSource{
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         print("Selected row at index: \(indexPath.row)")
+        print(indexPath)
+        delegate?.categoryDidSelect(at: indexPath)
     }
     
     func changeVisibility(forCellAt indexPath: IndexPath) {
@@ -142,8 +153,8 @@ class CategoryTableCell: UITableViewCell {
         return label
     }()
     
-    let iconView: UIView = {
-        let view = UIView()
+    let iconView: UIImageView = {
+        let view = UIImageView()
         view.backgroundColor = UIColor.mpDarkGray
         view.layer.cornerRadius = 16 // 동그라미의 반지름 설정
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -189,15 +200,21 @@ class CategoryTableCell: UITableViewCell {
     func configure(with category: Category) {
         titleLabel.text = category.name
         titleLabel.alpha = 1.0
+        if let iconName = category.categoryIcon {
+            iconView.image = UIImage(named: iconName)
+        }
         
         if category.isVisible! {
             eyeImageView.image = UIImage(systemName: "eye.fill")
             eyeImageView.tintColor = .mpGray
+            iconView.alpha = 1.0
         } else {
             eyeImageView.image = UIImage(systemName: "eye.slash.fill")
             eyeImageView.tintColor = .mpLightGray
             
             titleLabel.alpha = 0.4
+            iconView.alpha = 0.4
+
         }
     }
     
@@ -216,3 +233,4 @@ class CategoryTableCell: UITableViewCell {
         eyeImageView.addGestureRecognizer(tapGesture)
     }
 }
+

--- a/Money-Planner/Money-Planner/Model/Category/create/CreateCategoryRequest.swift
+++ b/Money-Planner/Money-Planner/Model/Category/create/CreateCategoryRequest.swift
@@ -1,0 +1,21 @@
+//
+//  CreateCategoryResponse.swift
+//  Money-Planner
+//
+//  Created by p_kxn_g on 2/18/24.
+//
+
+import Foundation
+
+struct CreateCategoryRequest: Codable {
+    let name: String
+    let icon: String
+   
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case icon
+    }
+
+   
+}

--- a/Money-Planner/Money-Planner/Model/Category/create/CreateCategoryResponse.swift
+++ b/Money-Planner/Money-Planner/Model/Category/create/CreateCategoryResponse.swift
@@ -1,0 +1,33 @@
+//
+//  CreateCategoryResponse.swift
+//  Money-Planner
+//
+//  Created by p_kxn_g on 2/18/24.
+//
+
+import Foundation
+
+struct CreateCategoryResponse: Decodable {
+    let isSuccess: Bool
+    let message: String
+    let result: CategoryDTO
+
+    enum CodingKeys: String, CodingKey {
+        case isSuccess
+        case message
+        case result
+    }
+  
+    struct CategoryDTO: Decodable {
+        let categoryId: Int64
+   
+
+        enum CodingKeys: String, CodingKey {
+            case categoryId
+        }
+    }
+ 
+    
+}
+
+

--- a/Money-Planner/Money-Planner/Model/Category/get/GetCategoryResponse.swift
+++ b/Money-Planner/Money-Planner/Model/Category/get/GetCategoryResponse.swift
@@ -1,0 +1,52 @@
+//
+//  GetCategoryResponse.swift
+//  Money-Planner
+//
+//  Created by p_kxn_g on 2/18/24.
+//
+
+import Foundation
+// api/category
+// 카테고리 조회 시 사용하는 구조
+struct GetCategoryResponse: Decodable {
+    let isSuccess: Bool
+    let message: String
+    let result: GetCategoryListResponse
+
+    enum CodingKeys: String, CodingKey {
+        case isSuccess
+        case message
+        case result
+    }
+    struct GetCategoryListResponse: Decodable {
+        let categories: [CategoryDTO]
+
+        enum CodingKeys: String, CodingKey {
+            case categories
+        }
+    }
+    struct CategoryDTO: Decodable {
+        let categoryId: Int64
+        let name: String
+        let icon: String
+        let priority : Int64
+        let isVisible : Bool
+        let type : String
+
+        enum CodingKeys: String, CodingKey {
+            case categoryId, name, icon, priority, isVisible,type
+        }
+    }
+    enum type: String, Decodable {
+        case DEFAULT = "DEFAULT"
+        case CUSTOM = "CUSTOM"
+      
+    }
+    
+}
+
+
+
+
+
+

--- a/Money-Planner/Money-Planner/Model/Category/get/ResponseGetCategoryListResponse.swift
+++ b/Money-Planner/Money-Planner/Model/Category/get/ResponseGetCategoryListResponse.swift
@@ -1,0 +1,43 @@
+//
+//  CategoryFilterResponse.swift
+//  Money-Planner
+//
+//  Created by p_kxn_g on 2/16/24.
+//
+
+import Foundation
+
+struct ResponseGetCategoryListResponse: Decodable {
+    let isSuccess: Bool
+    let message: String
+    let result: GetCategoryListResponse
+
+    enum CodingKeys: String, CodingKey {
+        case isSuccess
+        case message
+        case result
+    }
+}
+
+struct GetCategoryListResponse: Decodable {
+    let categories: [CategoryDTO]
+
+    enum CodingKeys: String, CodingKey {
+        case categories
+    }
+}
+
+struct CategoryDTO: Decodable {
+    let categoryId: Int64
+    let name: String
+    let icon: String
+
+    enum CodingKeys: String, CodingKey {
+        case categoryId
+        case name
+        case icon
+    }
+}
+
+
+

--- a/Money-Planner/Money-Planner/Model/DailyPlan/ZeroDayRequest.swift
+++ b/Money-Planner/Money-Planner/Model/DailyPlan/ZeroDayRequest.swift
@@ -1,0 +1,11 @@
+//
+//  ZeroDayRequest.swift
+//  Money-Planner
+//
+//  Created by p_kxn_g on 2/17/24.
+//
+
+import Foundation
+struct ZeroDayRequest : Encodable{
+    var dailyPlanDate : String
+}

--- a/Money-Planner/Money-Planner/Model/Expense/ExpenseCreateRequest.swift
+++ b/Money-Planner/Money-Planner/Model/Expense/ExpenseCreateRequest.swift
@@ -1,0 +1,42 @@
+//
+//  ExpenseCreateRequest.swift
+//  Money-Planner
+//
+//  Created by p_kxn_g on 2/14/24.
+//
+
+import Foundation
+
+struct ExpenseCreateRequest: Codable {
+    let expenseCost: Int64
+    let categoryId: Int64
+    let expenseTitle: String
+    let expenseMemo: String
+    let expenseDate: String
+    let routineRequest: RoutineRequest?
+    let isRoutine : Bool
+
+    enum CodingKeys: String, CodingKey {
+        case expenseCost
+        case categoryId
+        case expenseTitle
+        case expenseMemo
+        case expenseDate
+        case routineRequest
+        case isRoutine
+    }
+
+    struct RoutineRequest: Codable {
+        let type: RoutineType
+        let endDate: String?
+        let weeklyRepeatDays: [String]?
+        let weeklyTerm: String?
+        let monthlyRepeatDay: String?
+    }
+
+    enum RoutineType: String, Codable {
+        case weekly = "WEEKLY"
+        case monthly = "MONTHLY"
+    }
+}
+

--- a/Money-Planner/Money-Planner/Model/Expense/ExpenseCreateResponse.swift
+++ b/Money-Planner/Money-Planner/Model/Expense/ExpenseCreateResponse.swift
@@ -1,0 +1,63 @@
+//
+//  ExpenseCreateResponse.swift
+//  Money-Planner
+//
+//  Created by p_kxn_g on 2/14/24.
+//
+
+import Foundation
+
+struct ExpenseCreateResponse: Decodable {
+    let isSuccess: Bool
+    let message: String
+    let result: ExpenseResponse?
+
+    enum CodingKeys: String, CodingKey {
+        case isSuccess
+        case message
+        case result
+    }
+  
+    struct ExpenseResponse: Decodable {
+        let expenseId: Int64?
+        let alarms: [AlarmControlDTO]?
+
+        enum CodingKeys: String, CodingKey {
+            case expenseId
+            case alarms
+            
+        }
+
+        struct AlarmControlDTO: Decodable {
+            let alarmTitle: String?
+            let budget: Int64?
+            let excessAmount: Int64?
+
+            enum CodingKeys: String, CodingKey {
+                case alarmTitle
+                case budget
+                case excessAmount
+                init(from decoder: Decoder) throws {
+                       let container = try decoder.container(keyedBy: CodingKeys.self)
+                       
+                       if container.contains(.alarmTitle) {
+                           self = .alarmTitle
+                       } else if container.contains(.budget) {
+                           self = .budget
+                       } else if container.contains(.excessAmount) {
+                           self = .excessAmount
+                       } else {
+                           // Handle unknown case or set a default value
+                           throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: container.codingPath, debugDescription: "Unknown key"))
+                       }
+                   }
+            }
+
+            enum AlarmTitle: String, Decodable {
+                case day = "하루"
+                case category = "카테고리"
+                case all = "전체"
+            }
+        }
+    }
+}

--- a/Money-Planner/Money-Planner/Model/Expense/OverViewExpenseResponse.swift
+++ b/Money-Planner/Money-Planner/Model/Expense/OverViewExpenseResponse.swift
@@ -1,0 +1,38 @@
+//
+//  OverViewExpenseResponse.swift
+//  Money-Planner
+//
+//  Created by p_kxn_g on 2/18/24.
+//
+
+import Foundation
+
+struct OverViewExpenseResponse: Decodable {
+    let isSuccess: Bool
+    let message: String
+    let result: ExpenseOverView
+
+    enum CodingKeys: String, CodingKey {
+        case isSuccess
+        case message
+        case result
+    }
+    struct ExpenseOverView : Decodable {
+        let overview: [ZeroDayInfo]?
+
+        enum CodingKeys: String, CodingKey {
+            case overview
+        }
+    }
+    struct ZeroDayInfo: Decodable {
+        let date: String
+        let zeroDay : Bool
+       
+        enum CodingKeys: String, CodingKey {
+            case date, zeroDay
+        }
+    }
+
+}
+
+

--- a/Money-Planner/Money-Planner/Model/Expense/ResponseExpenseDto.swift
+++ b/Money-Planner/Money-Planner/Model/Expense/ResponseExpenseDto.swift
@@ -1,0 +1,25 @@
+//
+//  ExpenseIDResponse.swift
+//  Money-Planner
+//
+//  Created by p_kxn_g on 2/14/24.
+//
+
+import Foundation
+
+struct ResponseExpenseDto: Decodable {
+    let isSuccess: Bool
+    let message: String
+    let result: ExpenseDto
+
+    struct ExpenseDto: Decodable {
+        let expenseId: Int64
+        let date: String
+        let title: String
+        let memo: String
+        let cost: Int64
+        let categoryId: Int64
+        let categoryName: String
+        let categoryIcon: String
+    }
+}

--- a/Money-Planner/Money-Planner/Model/Expense/UpdateExpenseRequest.swift
+++ b/Money-Planner/Money-Planner/Model/Expense/UpdateExpenseRequest.swift
@@ -1,0 +1,18 @@
+//
+//  UpdateExpenseRequest.swift
+//  Money-Planner
+//
+//  Created by p_kxn_g on 2/14/24.
+//
+
+import Foundation
+
+struct UpdateExpenseRequest: Encodable {
+    var expenseId: Int64
+    var expenseCost : Int64
+    var categoryId: Int64
+    var expenseTitle: String
+    var expenseMemo: String
+    var expenseDate: String
+   
+}

--- a/Money-Planner/Money-Planner/Model/Member/ConnectModel.swift
+++ b/Money-Planner/Money-Planner/Model/Member/ConnectModel.swift
@@ -7,15 +7,13 @@
 
 import Foundation
 
-struct ConnectModel: Decodable {
+struct ConnectModel: Codable {
     let isSuccess: Bool
     let message: String?
     let result: ResultType?
 
-    struct ResultType: Decodable {
-        let key1: String
-        let key2: Int
-        // ... 다른 속성들
+    struct ResultType: Codable {
+        
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/Money-Planner/Money-Planner/Network/API/Category/CategoryAPI.swift
+++ b/Money-Planner/Money-Planner/Network/API/Category/CategoryAPI.swift
@@ -39,6 +39,6 @@ extension CategoryAPI : BaseAPI {
     }
     
     public var headers: [String: String]? {
-        return ["Authorization": "Bearer "]
+        return ["Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzMjkwMTA2OTM0IiwiYXV0aCI6IlVTRVIiLCJleHAiOjE3MDgzMzQ3NDR9.DArNLTr6H5OzdzxRekbIZUa-vLFrYBHgV0MW_o_j3Po"]
     }
 }

--- a/Money-Planner/Money-Planner/Network/API/Home/HomeAPI.swift
+++ b/Money-Planner/Money-Planner/Network/API/Home/HomeAPI.swift
@@ -81,7 +81,7 @@ extension HomeAPI : BaseAPI {
     
     public var headers: [String: String]? {
 
-        return ["Authorization": "Bearer  "]
+        return ["Authorization": "Bearer  eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzMjkwMTA2OTM0IiwiYXV0aCI6IlVTRVIiLCJleHAiOjE3MDgzMzQ3NDR9.DArNLTr6H5OzdzxRekbIZUa-vLFrYBHgV0MW_o_j3Po"]
 
     }
 }

--- a/Money-Planner/Money-Planner/Network/API/Test-park/MufflerAPI.swift
+++ b/Money-Planner/Money-Planner/Network/API/Test-park/MufflerAPI.swift
@@ -18,6 +18,7 @@ enum MufflerAPI {
     case updateExpense(expenseRequest: UpdateExpenseRequest)
     case getExpense(expenseId: Int64)
     case deleteExpense(expenseId: Int64)
+    case fetchAvailableExpenseDates(yearMonth : String)
     case getWeeklyExpense
     case searchExpense
     case getMonthlyExpense
@@ -76,6 +77,8 @@ extension MufflerAPI: TargetType {
             return "/api/expense/\(expenseId)"
         case .deleteExpense(let expenseId):
             return "/api/expense/\(expenseId)"
+        case .fetchAvailableExpenseDates(let yearMonth):
+            return "/api/expense/overview/\(yearMonth)"
         case .getWeeklyExpense:
             return "/api/expense/weekly"
         case .searchExpense:
@@ -122,7 +125,7 @@ extension MufflerAPI: TargetType {
         case .refreshToken, .loginKakao, .loginApple,
                 .createGoal, .createExpense, .updateRate, .updateZeroDay, .createCategory:
             return .post
-        case .connect, .getPreviousGoals, .getExpense, .getWeeklyExpense, .searchExpense,
+        case .connect, .getPreviousGoals, .getExpense, .getWeeklyExpense, .searchExpense, .fetchAvailableExpenseDates,
              .getMonthlyExpense, .getDailyExpense, .getRates, .getNow, .getGoal,
              .getGoalByYearMonth, .getGoalByCategory, .getBasicHomeInfo, .getCategoryFilter,.getCategory:
             return .get
@@ -139,7 +142,7 @@ extension MufflerAPI: TargetType {
         case .refreshToken, .loginKakao, .loginApple, .connect,
                 .createGoal, .getCategoryFilter,.getCategory,.updateRate, .updateZeroDay:
             return .requestPlain
-        case .getPreviousGoals, .getExpense, .getWeeklyExpense, .searchExpense,
+        case .getPreviousGoals, .getExpense,.fetchAvailableExpenseDates, .getWeeklyExpense, .searchExpense,
              .getMonthlyExpense, .getDailyExpense, .getRates, .getNow, .getGoal,
              .getGoalByYearMonth, .getGoalByCategory, .getBasicHomeInfo:
             return .requestPlain
@@ -162,6 +165,7 @@ extension MufflerAPI: TargetType {
 
     // Define headers for the request
     var headers: [String: String]? {
-        return ["Authorization": "Bearer "] // Replace with your actual access token
+        return ["Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzMjkwMTA2OTM0IiwiYXV0aCI6IlVTRVIiLCJleHAiOjE3MDgzMzQ3NDR9.DArNLTr6H5OzdzxRekbIZUa-vLFrYBHgV0MW_o_j3Po"] // Replace with your actual access token
     }
 }
+

--- a/Money-Planner/Money-Planner/Network/API/Test-park/MufflerAPI.swift
+++ b/Money-Planner/Money-Planner/Network/API/Test-park/MufflerAPI.swift
@@ -28,6 +28,9 @@ enum MufflerAPI {
     case getCategoryFilter
     case getCategory
     case createCategory(request : CreateCategoryRequest)
+    case updateCategory(request : UpdateCategoryRequest)
+    case deleteCategory(categoryId : Int64)
+
     // Daily Plan Controller
     case updateZeroDay
 
@@ -95,6 +98,10 @@ extension MufflerAPI: TargetType {
             return "api/category/filter"
         case .createCategory:
             return "api/category"
+        case .updateCategory:
+            return "api/category"
+        case .deleteCategory(let categoryId):
+            return "api/category/\(categoryId)"
         // Daily Plan Controller
         case .updateZeroDay:
             return "/dailyPlan/zeroDay"
@@ -129,9 +136,9 @@ extension MufflerAPI: TargetType {
              .getMonthlyExpense, .getDailyExpense, .getRates, .getNow, .getGoal,
              .getGoalByYearMonth, .getGoalByCategory, .getBasicHomeInfo, .getCategoryFilter,.getCategory:
             return .get
-        case .deleteGoal, .deleteExpense:
+        case .deleteGoal, .deleteExpense, .deleteCategory:
             return .delete
-        case .updateExpense:
+        case .updateExpense,.updateCategory:
             return .patch
         }
     }
@@ -140,13 +147,13 @@ extension MufflerAPI: TargetType {
     var task: Task {
         switch self {
         case .refreshToken, .loginKakao, .loginApple, .connect,
-                .createGoal, .getCategoryFilter,.getCategory,.updateRate, .updateZeroDay:
+                .createGoal, .getCategoryFilter,.getCategory,.updateRate, .updateZeroDay,.updateCategory:
             return .requestPlain
         case .getPreviousGoals, .getExpense,.fetchAvailableExpenseDates, .getWeeklyExpense, .searchExpense,
              .getMonthlyExpense, .getDailyExpense, .getRates, .getNow, .getGoal,
              .getGoalByYearMonth, .getGoalByCategory, .getBasicHomeInfo:
             return .requestPlain
-        case .deleteGoal, .deleteExpense:
+        case .deleteGoal, .deleteExpense, .deleteCategory:
             return .requestPlain
         case .createCategory(let request):
             return .requestJSONEncodable(request)

--- a/Money-Planner/Money-Planner/Network/API/Test-park/MufflerAPI.swift
+++ b/Money-Planner/Money-Planner/Network/API/Test-park/MufflerAPI.swift
@@ -147,7 +147,7 @@ extension MufflerAPI: TargetType {
     var task: Task {
         switch self {
         case .refreshToken, .loginKakao, .loginApple, .connect,
-                .createGoal, .getCategoryFilter,.getCategory,.updateRate, .updateZeroDay,.updateCategory:
+                .createGoal, .getCategoryFilter,.getCategory,.updateRate, .updateZeroDay:
             return .requestPlain
         case .getPreviousGoals, .getExpense,.fetchAvailableExpenseDates, .getWeeklyExpense, .searchExpense,
              .getMonthlyExpense, .getDailyExpense, .getRates, .getNow, .getGoal,
@@ -161,6 +161,9 @@ extension MufflerAPI: TargetType {
                 return .requestJSONEncodable(expenseRequest)
         case .updateExpense(let expenseRequest):
             return .requestJSONEncodable(expenseRequest)
+        case .updateCategory(let request):
+            return .requestJSONEncodable(request)
+
         }
         
     }

--- a/Money-Planner/Money-Planner/Network/API/Test-park/MufflerViewModel.swift
+++ b/Money-Planner/Money-Planner/Network/API/Test-park/MufflerViewModel.swift
@@ -148,6 +148,19 @@ class MufflerViewModel {
             .map(CreateCategoryResponse.self)
             .asObservable()
     }
+    
+    // 카테고리 수정
+    func updateCategory(categoryId : Int64) -> Observable<CreateCategoryResponse> {
+        return provider.request(.createCategory(request: request))
+            .map(CreateCategoryResponse.self)
+            .asObservable()
+    }
+    // 카테고리 삭제
+    func deleteCategory(categoryId : Int64) -> Observable<CreateCategoryResponse> {
+        return provider.request(.createCategory(request: request))
+            .map(CreateCategoryResponse.self)
+            .asObservable()
+    }
 //
 //    // Rate Controller
 //    func updateRate(date: String) -> Observable<MyRepo> {

--- a/Money-Planner/Money-Planner/Network/API/Test-park/MufflerViewModel.swift
+++ b/Money-Planner/Money-Planner/Network/API/Test-park/MufflerViewModel.swift
@@ -150,15 +150,15 @@ class MufflerViewModel {
     }
     
     // 카테고리 수정
-    func updateCategory(categoryId : Int64) -> Observable<CreateCategoryResponse> {
-        return provider.request(.createCategory(request: request))
-            .map(CreateCategoryResponse.self)
+    func updateCategory(request : UpdateCategoryRequest ) -> Observable<ConnectModel> {
+        return provider.request(.updateCategory(request: request))
+            .map(ConnectModel.self)
             .asObservable()
     }
     // 카테고리 삭제
-    func deleteCategory(categoryId : Int64) -> Observable<CreateCategoryResponse> {
-        return provider.request(.createCategory(request: request))
-            .map(CreateCategoryResponse.self)
+    func deleteCategory(categoryId : Int64) -> Observable<DeleteCategoryResponse> {
+        return provider.request(.deleteCategory(categoryId: categoryId))
+            .map(DeleteCategoryResponse.self)
             .asObservable()
     }
 //

--- a/Money-Planner/Money-Planner/Network/API/Test-park/MufflerViewModel.swift
+++ b/Money-Planner/Money-Planner/Network/API/Test-park/MufflerViewModel.swift
@@ -12,7 +12,15 @@ import Moya
 
 class MufflerViewModel {
     private let provider = MoyaProvider<MufflerAPI>().rx
-
+    let disposeBag = DisposeBag()
+    // 소비등록 > 달력 모달뷰
+    // 초기값이 필요한 BehaviorSubject 선언
+    private let expenseOverviewSubject = BehaviorSubject<OverViewExpenseResponse?>(value: nil)
+    // 외부에서 구독 가능하도록 Observable로 노출
+    var expenseOverviewObservable: Observable<OverViewExpenseResponse?> {
+        return expenseOverviewSubject.asObservable()
+    }
+    
     // Member Controller
 //    func refreshToken() -> Observable<MyRepo> {
 //        return provider.request(.refreshToken)
@@ -56,27 +64,45 @@ class MufflerViewModel {
 //            .asObservable()
 //    }
 //
-//    // Expense Controller
-    // 소비내역 등록
+    // Expense Controller
+    
+    // 소비내역 등록 : [POST] /api/expense
     func createExpense(expenseRequest: ExpenseCreateRequest) -> Single<ExpenseCreateResponse> {
         return provider.request(.createExpense(expenseRequest: expenseRequest))
                 .map(ExpenseCreateResponse.self)
     }
-    // 소비내역 수정
+    // 소비내역 수정 : [PATCH] /api/expense
     func updateExpense(expenseRequest: UpdateExpenseRequest) -> Single<ExpenseCreateResponse> {
         return provider.request(.updateExpense(expenseRequest: expenseRequest))
             .map(ExpenseCreateResponse.self)
     }
-    // 소비내역 조회
+  
+    // 소비내역 삭제 : [DELETE] /api/expense/{expenseId}
+    func deleteExpense(expenseId: Int64) -> Observable<ConnectModel> {
+        return provider.request(.deleteExpense(expenseId: expenseId))
+            .map(ConnectModel.self).asObservable()
+    }
+    
+    // 소비가능날짜 조회 : [GET] /api/expense/overview/{yearMonth}
+    func fetchAvailableExpenseDates(yearMonth : String){
+        provider.request(.fetchAvailableExpenseDates(yearMonth: yearMonth))
+                .map(OverViewExpenseResponse.self)
+                .subscribe(onSuccess: { [weak self] response in
+                    // BehaviorSubject 업데이트
+                    self?.expenseOverviewSubject.onNext(response)
+                }, onError: { [weak self] error in
+                    print("Error: \(error)")
+                    // 에러 핸들링 필요시 여기서 처리
+                    self?.expenseOverviewSubject.onNext(nil)
+                }).disposed(by: disposeBag)
+    }
+    
+    // Expense View Controller
+    // 일일소비내역 조회 : [GET] /api/expense/{expenseId}
     func getExpense(expenseId: Int64) -> Observable<ResponseExpenseDto> {
         return provider.request(.getExpense(expenseId: expenseId))
             .map(ResponseExpenseDto.self)
             .asObservable()
-    }
-    // 소비내역 삭제
-    func deleteExpense(expenseId: Int64) -> Observable<ConnectModel> {
-        return provider.request(.deleteExpense(expenseId: expenseId))
-            .map(ConnectModel.self).asObservable()
     }
 //
 //    func getWeeklyExpense() -> Observable<MyRepo> {
@@ -172,3 +198,4 @@ class MufflerViewModel {
 //            .asObservable()
 //    }
 }
+

--- a/Money-Planner/Money-Planner/Notification/ExpenseZeroDayView.swift
+++ b/Money-Planner/Money-Planner/Notification/ExpenseZeroDayView.swift
@@ -1,0 +1,134 @@
+//
+//  ExpenseZeroDayView.swift
+//  Money-Planner
+//
+//  Created by p_kxn_g on 2/18/24.
+//
+
+import Foundation
+import UIKit
+
+class ExpenseZeroDayView : UIViewController {
+    
+    var rateInfo : RateInfo?
+    var dateText = ""
+    
+    let customModal = UIView(frame: CGRect(x: 0, y: 0, width: 322, height: 400))
+    
+    let titleLabel: MPLabel = {
+        let label = MPLabel()
+        label.text = ""
+        label.numberOfLines = 0
+        label.font = UIFont.mpFont20B()
+        
+        return label
+    }()
+    
+    let contentLabel : MPLabel = {
+        let label = MPLabel()
+        label.text = ""
+        label.numberOfLines = 0
+        label.font = UIFont.mpFont16M()
+        
+        return label
+    }()
+    
+    let ImageView : UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.mpGray
+        
+        return view
+    }()
+    
+    let controlButtons = SmallBtnView()
+    
+    let confirmButton : UIButton = {
+        let button = UIButton()
+        button.setTitle("확인", for: .normal)
+        button.setTitleColor(UIColor.mpWhite, for: .normal)
+        button.backgroundColor = UIColor.mpMainColor
+        button.layer.cornerRadius = 12
+        button.clipsToBounds = true
+        
+        return button
+    }()
+    
+    // 모달 제목 바꾸는 함수
+    func changeTitle(title : String){
+        titleLabel.text = title
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        //fetchRateData()
+        presentCustomModal()
+        setupBackground()
+        setupCancelZeroView()
+    }
+    
+    func presentCustomModal() {
+        customModal.backgroundColor = UIColor.mpWhite
+        view.addSubview(customModal)
+        customModal.center = view.center
+        
+    }
+    
+    private func setupBackground() {
+        view.backgroundColor = UIColor.mpDim
+        customModal.layer.cornerRadius = 25
+        customModal.layer.masksToBounds = true
+    }
+    
+    
+    
+    private func setupCancelZeroView() {
+        customModal.addSubview(titleLabel)
+        customModal.addSubview(contentLabel)
+        
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 5
+        
+        let titleAttributedText = NSAttributedString(string: "해당날짜는 '0원소비'를\n등록해둔 날이에요", attributes: [NSAttributedString.Key.paragraphStyle: paragraphStyle])
+        titleLabel.attributedText = titleAttributedText
+        titleLabel.textAlignment = .center
+       
+        let contentAttributedText = NSAttributedString(string: "이 날짜에 소비등록을 하려면\n'0원소비'를 해제해야해요", attributes: [NSAttributedString.Key.paragraphStyle: paragraphStyle])
+        contentLabel.attributedText = contentAttributedText
+        contentLabel.textAlignment = .center
+        
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        contentLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: customModal.topAnchor, constant: 35),
+            titleLabel.centerXAnchor.constraint(equalTo: customModal.centerXAnchor),
+            
+            contentLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 15),
+            contentLabel.centerXAnchor.constraint(equalTo: customModal.centerXAnchor)
+            
+        ])
+        
+        ImageView.translatesAutoresizingMaskIntoConstraints = false
+        controlButtons.translatesAutoresizingMaskIntoConstraints = false
+        
+        customModal.addSubview(ImageView)
+        customModal.addSubview(controlButtons)
+        
+        controlButtons.cancelButton.setTitle("취소", for: .normal)
+        controlButtons.completeButton.setTitle("해제하기", for: .normal)
+        
+        NSLayoutConstraint.activate([
+            ImageView.leadingAnchor.constraint(equalTo: customModal.leadingAnchor, constant: 87),
+            ImageView.trailingAnchor.constraint(equalTo: customModal.trailingAnchor, constant: -87),
+            ImageView.bottomAnchor.constraint(equalTo: controlButtons.topAnchor, constant: -50),
+            ImageView.heightAnchor.constraint(equalToConstant: 87),
+            
+            controlButtons.bottomAnchor.constraint(equalTo: customModal.bottomAnchor, constant: -15),
+            controlButtons.leadingAnchor.constraint(equalTo: customModal.leadingAnchor, constant: 15),
+            controlButtons.trailingAnchor.constraint(equalTo: customModal.trailingAnchor, constant: -15),
+            controlButtons.heightAnchor.constraint(equalToConstant: 58)
+        ])
+    }
+}
+

--- a/Money-Planner/Money-Planner/View/Consume/Calendar/CalendartModalViewController.swift
+++ b/Money-Planner/Money-Planner/View/Consume/Calendar/CalendartModalViewController.swift
@@ -7,16 +7,34 @@
 
 import Foundation
 import UIKit
+import RxSwift
+import RxCocoa
 
 protocol CalendarSelectionDelegate : AnyObject{
     func didSelectCalendarDate(_ date : String,  api : String)
 }
 class CalendartModalViewController : UIViewController{
     weak var delegate: CalendarSelectionDelegate?
+    
+    var OverviewExpenseDates : [OverViewExpenseResponse.ZeroDayInfo] = []
+    var disableExpenseDates : [String] = []
+    var zeroDayList : [Bool] = []
 
-    //let customModal = UIView(frame: CGRect(x: 0, y: 0, width: 361, height: 548))
-    var decorations: [Date?: UICalendarView.Decoration]?
-
+    let disposeBag = DisposeBag()
+    let viewModel = MufflerViewModel()
+    var checkedDate : String = ""
+    var checkedMonth : String = ""
+    let currentDate = Date()
+    let dateFormatter = DateFormatter()
+    lazy var todayMonth: String = {
+        dateFormatter.dateFormat = "yyyy-MM"
+        return dateFormatter.string(from: currentDate)
+    }()
+    lazy var todayDate: String = {
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        return dateFormatter.string(from: currentDate)
+    }()
+    
     // 모달의 메인 컨테이너 뷰
     private let customModal: UIView = {
         let view = UIView()
@@ -32,36 +50,31 @@ class CalendartModalViewController : UIViewController{
         label.text = "소비 날짜를 선택해주세요"
         label.textAlignment = .center
         label.font = UIFont.mpFont20B()
+        label.textColor = .mpBlack
+        return label
+    }()
+    let errorLabel : UILabel = {
+        let label = UILabel()
+        label.text = "목표가 존재하지 않는 날입니다."
+        label.textColor = .clear
+        label.textAlignment = .center
+        label.font = UIFont.mpFont14M()
         return label
     }()
     let containerView = UIView()
-    let datePicker : UICalendarView = {
-        let datePicker = UICalendarView()
+
+    let datePicker :UIDatePicker = {
+        let datePicker = UIDatePicker()
         datePicker.locale = Locale(identifier: "ko_KR")
+        datePicker.preferredDatePickerStyle = .inline
+        datePicker.datePickerMode = .date
         datePicker.tintColor = .mpMainColor
+
+        datePicker.translatesAutoresizingMaskIntoConstraints = false
         return datePicker
     }()
-//    let datePicker :UIDatePicker = {
-//        let datePicker = UIDatePicker()
-//        datePicker.locale = Locale(identifier: "ko_KR")
-//        datePicker.preferredDatePickerStyle = .inline
-//        datePicker.datePickerMode = .date
-//        datePicker.tintColor = .mpMainColor
-//        //datePicker.addTarget(self, action: #selector(datePickerValueChanged(_:)), for: .valueChanged)
-//        //datePicker.backgroundColor = .mpRed
-//        datePicker.translatesAutoresizingMaskIntoConstraints = false
-//        return datePicker
-//    }()
    // let datePicker = UIPickerView()
-    let completeButton : UIButton = {
-        let button = UIButton()
-        button.setTitle("완료", for: .normal)
-        button.setTitleColor(UIColor.mpWhite, for: .normal)
-        button.backgroundColor = UIColor.mpMainColor
-        button.layer.cornerRadius = 11  // 적절한 둥글기 값 설정
-        button.clipsToBounds = true
-        return button
-    }()
+    let completeButton = MainBottomBtn(title: "완료")
     let chooseTodayButton: UIButton = {
         let button = UIButton()
         button.setTitle("오늘 선택하기", for: .normal)
@@ -85,32 +98,46 @@ class CalendartModalViewController : UIViewController{
     func changeTitle(title : String){
         titleLabel.text = title
     }
+    
+    func setupBindings() {
+        viewModel.expenseOverviewObservable
+            .subscribe(onNext: { [weak self] response in
+                guard let self = self, let response = response else { return }
+                self.OverviewExpenseDates = response.result.overview ?? []
+                // 필요한 UI 업데이트 로직 호출, 예를 들어 tableView.reloadData()
+                print(self.OverviewExpenseDates)
+                updateError()
+            })
+            .disposed(by: disposeBag)
+    }
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        setupBindings()
+    }
+   
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
+        // 오늘이 속한 월 구해서 api 연결
+        
+        checkedDate = todayDate
+        checkedMonth = todayMonth
+        
+        // 데이터 요청
+        viewModel.fetchAvailableExpenseDates(yearMonth: checkedMonth)
+        
+        // UI
         presentCustomModal()
         setuptitleLabel()
         setupCalendarCellContainerView()
         setupCompleteButton()
         
-        // UICalendarView의 Delegate를 설정합니다.
-        datePicker.delegate = self
-        
-        // 날짜 선택 동작을 설정합니다.
-        let dateSelection = UICalendarSelectionSingleDate(delegate: self)
-        datePicker.selectionBehavior = dateSelection
-        
-        let valentinesDay = DateComponents(
-                    calendar: Calendar(identifier: .gregorian),
-                    year: 2024,
-                    month: 2,
-                    day: 14
-                )
-                
-        // Create a calendar decoration for Valentine's day.
-        let heart = UICalendarView.Decoration.default()
-        
-        
-        decorations = [valentinesDay.date: heart]
+        // 액션
+        datePicker.addTarget(self, action: #selector(datePickerValueChanged(_:)), for: .valueChanged)
+
     }
     
     func presentCustomModal() {
@@ -132,26 +159,32 @@ class CalendartModalViewController : UIViewController{
         
         customModal.addSubview(modalBar)
         customModal.addSubview(titleLabel)
+        customModal.addSubview(errorLabel)
+
         modalBar.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
-       
+        errorLabel.translatesAutoresizingMaskIntoConstraints = false
+
         NSLayoutConstraint.activate([
             modalBar.widthAnchor.constraint(equalToConstant: 49),
             modalBar.heightAnchor.constraint(equalToConstant: 4),
             modalBar.topAnchor.constraint(equalTo: customModal.topAnchor, constant: 12),
             modalBar.centerXAnchor.constraint(equalTo: customModal.centerXAnchor),
             titleLabel.topAnchor.constraint(equalTo: modalBar.bottomAnchor, constant: 28),
+            titleLabel.heightAnchor.constraint(equalToConstant: 28),
+
             titleLabel.centerXAnchor.constraint(equalTo: customModal.centerXAnchor),
+            errorLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 2),
+            errorLabel.centerXAnchor.constraint(equalTo: customModal.centerXAnchor),
+            errorLabel.heightAnchor.constraint(equalToConstant: 23),
             ])
         
         containerView.translatesAutoresizingMaskIntoConstraints = false
-        //containerView.backgroundColor = .mpDim
         customModal.addSubview(containerView)
         NSLayoutConstraint.activate([
             containerView.leadingAnchor.constraint(equalTo: customModal.leadingAnchor, constant: 9),
             containerView.trailingAnchor.constraint(equalTo: customModal.trailingAnchor, constant: -9),
-            containerView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 24),
-            //containerView.bottomAnchor.constraint(equalTo: customModal.bottomAnchor, constant: -72)
+            containerView.topAnchor.constraint(equalTo: errorLabel.bottomAnchor, constant: 5),
         ])
             
     }
@@ -173,7 +206,6 @@ class CalendartModalViewController : UIViewController{
     // 세팅 : 오늘 선택하기와 완료 버튼
     private func setupCompleteButton(){
         customModal.addSubview(completeButton)
-        completeButton.isUserInteractionEnabled = true
         completeButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             completeButton.widthAnchor.constraint(equalToConstant: 164),
@@ -194,62 +226,113 @@ class CalendartModalViewController : UIViewController{
         ])
         chooseTodayButton.addTarget(self, action: #selector(todayButtonTapped), for: .touchUpInside)
     }
-    @objc func datePickerValueChanged(_ sender: UIDatePicker) {
-            let selectedDate = sender.date
-            print("Selected Date: \(selectedDate)")
+    
+    // UIDatePicker의 값이 변경될 때 호출될 메서드
+   @objc func datePickerValueChanged(_ sender: UIDatePicker) {
+       // 선택된 날짜를 출력하거나 처리
+       let dateFormatter = DateFormatter()
+       dateFormatter.dateFormat = "yyyy-MM-dd"
+       let selectedDate = dateFormatter.string(from: sender.date)
+       checkedDate = selectedDate
+       print("선택된 날짜: \(selectedDate)")
+       
+       updateError()
+       //선택된 달이 바뀌는 경우 - 다시 데이터 받기
+       dateFormatter.dateFormat = "yyyy-MM"
+       let selectedMonth = dateFormatter.string(from: sender.date)
+       
+       // 새로운 달로 넘어간 경우
+       if checkedMonth != selectedMonth {
+           print(selectedMonth)
+           checkedMonth = selectedMonth
+           viewModel.fetchAvailableExpenseDates(yearMonth: selectedMonth)
+       }
+   }
+    private func updateError(){
+        print(checkedDate)
+        if let currentDateInfo = OverviewExpenseDates.first(where: { $0.date == checkedDate }) {
+            removeError()
+            print(currentDateInfo)
+            print("소비 가능 날짜에 포함되어 있음")
+            if currentDateInfo.zeroDay {
+                // 제로데이인 경우 알람 띄우기
+                presentZeroDayModal()
+            }
+            else{
+                completeButton.isEnabled = true
+            }
+            
+        }else{
+            addError()
+            completeButton.isEnabled = false
         }
-
+    }
     
     @objc private func completeButtonTapped() {
         print("완료 버튼이 탭되었습니다.")
+        // 화면 보여주기 용
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy년 MM월 dd일"
-        //let selectedDate = dateFormatter.string(from: datePicker.date)
+        let selectedDate = dateFormatter.string(from: datePicker.date)
+        
         // api 전달용
         dateFormatter.dateFormat = "yyyy-MM-dd"
-        //let apiDate = dateFormatter.string(from: datePicker.date)
-        //delegate?.didSelectCalendarDate(selectedDate, api : apiDate)
+        let apiDate = dateFormatter.string(from: datePicker.date)
+        delegate?.didSelectCalendarDate(selectedDate, api : apiDate)
         dismiss(animated: true, completion: nil as (() -> Void)?)
         // 완료 버튼 액션 처리
     }
     @objc private func todayButtonTapped() {
         print("오늘 선택하기 버튼이 탭되었습니다.")
-        //datePicker.setDate(Date(), animated: true)
+        datePicker.setDate(Date(), animated: true)
         // 완료 버튼 액션 처리
     }
+ 
     
+    private func removeError(){
+        errorLabel.textColor = .clear
+    }
+    private func addError(){
+        errorLabel.textColor = .mpRed
+    }
     
-    
-    
-    
-}
+    private func presentZeroDayModal() {
+            let rateContent = "rateInfo"
+            let customModalVC = ExpenseZeroDayView()
+            customModalVC.modalPresentationStyle = .overFullScreen
+            customModalVC.modalTransitionStyle = .crossDissolve
+            present(customModalVC, animated: true, completion: nil)
+            customModalVC.controlButtons.cancelButton.addTarget(self, action: #selector(dismissCustomModal), for: .touchUpInside)
+            customModalVC.controlButtons.completeButton.addTarget(self, action: #selector(cancelZero), for: .touchUpInside)
 
-extension CalendartModalViewController : UICalendarViewDelegate, UICalendarSelectionSingleDateDelegate{
-    
-    
-    func dateSelection(_ selection: UICalendarSelectionSingleDate, didSelectDate dateComponents: DateComponents?) {
-        if let currDate = dateComponents{
-            print(currDate)
         }
+    @objc private func dismissCustomModal() {
+             // 모달 닫기
+            print("모달닫기")
+             dismiss(animated: true, completion: nil)
+         }
         
-    }
-  
+    @objc private func cancelZero() {
+        print("제로데이 해제하기")
+        checkZeroDay()
+        dismiss(animated: true, completion: nil)
+     }
+    
 
     
-    // Return a decoration (if any) for the specified day.
-    func calendarView(_ calendarView: UICalendarView, decorationFor dateComponents: DateComponents) -> UICalendarView.Decoration? {
-        // Get a copy of the date components that only contain
-        // the calendar, year, month, and day.
-        let day = DateComponents(
-            calendar: dateComponents.calendar,
-            year: dateComponents.year,
-            month: dateComponents.month,
-            day: dateComponents.day
-        )
-        
-        // Return any decoration saved for that date.
-        return decorations![day.date]
+    func checkZeroDay() {
+        ExpenseRepository.shared.isZeroDay(dailyPlanDate: checkedDate) { result in
+            switch result {
+            case .success(let updatedInfo):
+                print("zero updated successfully: \(String(describing: updatedInfo))")
+            case .failure(let error):
+                print("Failed to update zero info: \(error)")
+            }
+        }
     }
     
+    
+    
 }
+
 

--- a/Money-Planner/Money-Planner/View/Consume/ConsumeDetailViewController.swift
+++ b/Money-Planner/Money-Planner/View/Consume/ConsumeDetailViewController.swift
@@ -46,7 +46,7 @@ class ConsumeDetailViewController: UIViewController, UITextFieldDelegate, Catego
     //
 
     func AddCategory() {
-        let addCategoryVC = AddCategoryViewController(name: "", icon: "")
+        let addCategoryVC = AddCategoryViewController(name: "", icon: "", id: -1)
         addCategoryVC.modalPresentationStyle = .fullScreen
         addCategoryVC.delegate = self
         present(addCategoryVC, animated: true)

--- a/Money-Planner/Money-Planner/View/Consume/ConsumeDetailViewController.swift
+++ b/Money-Planner/Money-Planner/View/Consume/ConsumeDetailViewController.swift
@@ -46,7 +46,7 @@ class ConsumeDetailViewController: UIViewController, UITextFieldDelegate, Catego
     //
 
     func AddCategory() {
-        let addCategoryVC = AddCategoryViewController()
+        let addCategoryVC = AddCategoryViewController(name: "", icon: "")
         addCategoryVC.modalPresentationStyle = .fullScreen
         addCategoryVC.delegate = self
         present(addCategoryVC, animated: true)

--- a/Money-Planner/Money-Planner/View/Consume/ConsumeViewController.swift
+++ b/Money-Planner/Money-Planner/View/Consume/ConsumeViewController.swift
@@ -44,7 +44,7 @@ class ConsumeViewController: UIViewController,UITextFieldDelegate, CategorySelec
         view.layoutIfNeeded()
     }
     func AddCategory() {
-        let addCategoryVC = AddCategoryViewController()
+        let addCategoryVC = AddCategoryViewController(name: "", icon: "")
         addCategoryVC.modalPresentationStyle = .fullScreen
         addCategoryVC.delegate = self
         present(addCategoryVC, animated: true)

--- a/Money-Planner/Money-Planner/View/Consume/ConsumeViewController.swift
+++ b/Money-Planner/Money-Planner/View/Consume/ConsumeViewController.swift
@@ -44,7 +44,7 @@ class ConsumeViewController: UIViewController,UITextFieldDelegate, CategorySelec
         view.layoutIfNeeded()
     }
     func AddCategory() {
-        let addCategoryVC = AddCategoryViewController(name: "", icon: "")
+        let addCategoryVC = AddCategoryViewController(name: "", icon: "", id: -1)
         addCategoryVC.modalPresentationStyle = .fullScreen
         addCategoryVC.delegate = self
         present(addCategoryVC, animated: true)

--- a/Money-Planner/Money-Planner/View/Home/CategoryEditViewController.swift
+++ b/Money-Planner/Money-Planner/View/Home/CategoryEditViewController.swift
@@ -13,7 +13,7 @@ class CategoryEditViewController : UIViewController,CategoryTableViewDelegate, A
         let category = categoryList[indexPath.item]
         categoryName = category.name
         categoryIcon = category.categoryIcon
-        
+        categoryId = Int64(category.id)
         presentCategoryDetail()
     }
     
@@ -42,6 +42,7 @@ class CategoryEditViewController : UIViewController,CategoryTableViewDelegate, A
     var categoryList : [Category] = []
     var categoryName : String?
     var categoryIcon : String?
+    var categoryId : Int64?
     private let canEditLabel: MPLabel = {
         let label = MPLabel()
         label.text = "카테고리 순서를 편집할 수 있습니다."
@@ -126,7 +127,7 @@ extension CategoryEditViewController{
     }
   
     func presentCategoryDetail(){
-        let catDetailVC = AddCategoryViewController(name: categoryName ?? "", icon: categoryIcon ?? "")
+        let catDetailVC = AddCategoryViewController(name: categoryName ?? "", icon: categoryIcon ?? "", id : categoryId ?? -1)
             catDetailVC.modalPresentationStyle = .overFullScreen
             catDetailVC.delegate = self
             present(catDetailVC, animated: true)
@@ -136,7 +137,7 @@ extension CategoryEditViewController{
     private func addButtonTapped() {
         print("add button tapped")
         // 카테고리 추가화면
-        let addCategoryVC = AddCategoryViewController(name: "", icon: "")
+        let addCategoryVC = AddCategoryViewController(name: "", icon: "", id: -1)
         addCategoryVC.modalPresentationStyle = .fullScreen
         addCategoryVC.delegate = self
         present(addCategoryVC, animated: true)

--- a/Money-Planner/Money-Planner/View/Home/CategoryEditViewController.swift
+++ b/Money-Planner/Money-Planner/View/Home/CategoryEditViewController.swift
@@ -8,7 +8,15 @@
 import Foundation
 import UIKit
 
-class CategoryEditViewController : UIViewController, AddCategoryViewDelegate {
+class CategoryEditViewController : UIViewController,CategoryTableViewDelegate, AddCategoryViewDelegate {
+    func categoryDidSelect(at indexPath: IndexPath) {
+        let category = categoryList[indexPath.item]
+        categoryName = category.name
+        categoryIcon = category.categoryIcon
+        
+        presentCategoryDetail()
+    }
+    
     func AddCategoryCompleted(_ name: String, iconName: String) {
         // 카테고리 추가 후 실행되는 함수
         
@@ -32,7 +40,8 @@ class CategoryEditViewController : UIViewController, AddCategoryViewDelegate {
     }()
         
     var categoryList : [Category] = []
-    
+    var categoryName : String?
+    var categoryIcon : String?
     private let canEditLabel: MPLabel = {
         let label = MPLabel()
         label.text = "카테고리 순서를 편집할 수 있습니다."
@@ -76,7 +85,7 @@ extension CategoryEditViewController{
     func setupUI(){
         
         categoryTableView.categoryList = categoryList
-        
+        categoryTableView.delegate = self
         
         view.addSubview(categoryTableView)
         view.addSubview(canCategoryEditGrayView)
@@ -115,12 +124,19 @@ extension CategoryEditViewController{
             }
         }
     }
+  
+    func presentCategoryDetail(){
+        let catDetailVC = AddCategoryViewController(name: categoryName ?? "", icon: categoryIcon ?? "")
+            catDetailVC.modalPresentationStyle = .overFullScreen
+            catDetailVC.delegate = self
+            present(catDetailVC, animated: true)
+        }
     
-    @objc 
+    @objc
     private func addButtonTapped() {
         print("add button tapped")
         // 카테고리 추가화면
-        let addCategoryVC = AddCategoryViewController()
+        let addCategoryVC = AddCategoryViewController(name: "", icon: "")
         addCategoryVC.modalPresentationStyle = .fullScreen
         addCategoryVC.delegate = self
         present(addCategoryVC, animated: true)

--- a/Money-Planner/Money-Planner/ViewModel/Category/delete/DeleteCategoryResponse.swift
+++ b/Money-Planner/Money-Planner/ViewModel/Category/delete/DeleteCategoryResponse.swift
@@ -1,0 +1,36 @@
+//
+//  DeleteCategoryRequest.swift
+//  Money-Planner
+//
+//  Created by p_kxn_g on 2/19/24.
+//
+
+import Foundation
+
+struct DeleteCategoryResponse: Decodable {
+    let isSuccess: Bool
+    let message: String
+    let result: DeleteCategory?
+
+    enum CodingKeys: String, CodingKey {
+        case isSuccess
+        case message
+        case result
+    }
+    struct DeleteCategory: Decodable {
+        let updatedRoutineRows: Int32
+
+
+        enum CodingKeys: String, CodingKey {
+            case updatedRoutineRows
+        }
+    }
+}
+   
+
+
+
+
+
+
+

--- a/Money-Planner/Money-Planner/ViewModel/Expense/OverViewExpenseResponse.swift
+++ b/Money-Planner/Money-Planner/ViewModel/Expense/OverViewExpenseResponse.swift
@@ -1,0 +1,38 @@
+//
+//  OverViewExpenseResponse.swift
+//  Money-Planner
+//
+//  Created by p_kxn_g on 2/18/24.
+//
+
+import Foundation
+
+struct OverViewExpenseResponse: Decodable {
+    let isSuccess: Bool
+    let message: String
+    let result: ExpenseOverView
+
+    enum CodingKeys: String, CodingKey {
+        case isSuccess
+        case message
+        case result
+    }
+    struct ExpenseOverView : Decodable {
+        let overview: [ZeroDayInfo]?
+
+        enum CodingKeys: String, CodingKey {
+            case overview
+        }
+    }
+    struct ZeroDayInfo: Decodable {
+        let date: String
+        let zeroDay : Bool
+       
+        enum CodingKeys: String, CodingKey {
+            case date, zeroDay
+        }
+    }
+
+}
+
+

--- a/Money-Planner/Money-Planner/ViewModel/Expense/UpdateCategoryRequest.swift
+++ b/Money-Planner/Money-Planner/ViewModel/Expense/UpdateCategoryRequest.swift
@@ -1,0 +1,22 @@
+//
+//  UpdateCategoryRequest.swift
+//  Money-Planner
+//
+//  Created by p_kxn_g on 2/19/24.
+//
+
+import Foundation
+struct UpdateCategoryRequest: Codable {
+    let categoryId : Int64
+    let name: String
+    let icon: String
+   
+
+    enum CodingKeys: String, CodingKey {
+        case categoryId
+        case name
+        case icon
+    }
+
+   
+}


### PR DESCRIPTION
1. 소비등록/ 소비 수정 : 달력 선택뷰 수정
- 목표가 있는 기간만 선택 가능
- 제로데이 선택한 경우 제로데이 모달 띄우기 (취소,해제)

2. 카테고리 수정/삭제 화면
- api 연결 완료
- 카테고리 수정/삭제 화면 및 로직